### PR TITLE
Support string separator instead of rune

### DIFF
--- a/encosures_test.go
+++ b/encosures_test.go
@@ -1,10 +1,10 @@
 package splitter
 
 import (
-	"fmt"
-	"github.com/stretchr/testify/require"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 var testEnclosures = map[string]*Enclosure{
@@ -81,7 +81,7 @@ var testEnclosures = map[string]*Enclosure{
 
 func TestEnclosures(t *testing.T) {
 	for name, enc := range testEnclosures {
-		t.Run(fmt.Sprintf("%s", name), func(t *testing.T) {
+		t.Run("%s", func(t *testing.T) {
 			require.NotEqual(t, rune(0), enc.Start)
 			require.NotEqual(t, rune(0), enc.End)
 			if strings.Contains(name, "Quote") {

--- a/errors_test.go
+++ b/errors_test.go
@@ -3,8 +3,9 @@ package splitter
 import (
 	"errors"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestWrappedSplittingError(t *testing.T) {
@@ -74,13 +75,13 @@ func TestNewOptionFailError(t *testing.T) {
 }
 
 func TestSplitAlwaysReturnsSplittingError(t *testing.T) {
-	s, err := NewSplitter(',', Parenthesis)
+	s, err := NewSplitter(",", Parenthesis)
 	require.NoError(t, err)
 	s.AddDefaultOptions(NotEmptyFirstMsg("whoops at position %d"))
 
-	_, err = s.Split(`(`)
+	_, err = s.Split("(")
 	require.Error(t, err)
-	require.Equal(t, fmt.Sprintf(unclosedFmt, `(`, 0), err.Error())
+	require.Equal(t, fmt.Sprintf(unclosedFmt, "(", 0), err.Error())
 	sErr, ok := err.(SplittingError)
 	require.True(t, ok)
 	require.Equal(t, Unclosed, sErr.Type())
@@ -89,9 +90,9 @@ func TestSplitAlwaysReturnsSplittingError(t *testing.T) {
 	require.Equal(t, Parenthesis, sErr.Enclosure())
 	require.Nil(t, sErr.Wrapped())
 
-	_, err = s.Split(`)`)
+	_, err = s.Split(")")
 	require.Error(t, err)
-	require.Equal(t, fmt.Sprintf(unopenedFmt, `)`, 0), err.Error())
+	require.Equal(t, fmt.Sprintf(unopenedFmt, ")", 0), err.Error())
 	sErr, ok = err.(SplittingError)
 	require.True(t, ok)
 	require.Equal(t, Unopened, sErr.Type())
@@ -102,9 +103,9 @@ func TestSplitAlwaysReturnsSplittingError(t *testing.T) {
 	require.NoError(t, sErr.Unwrap())
 	require.NoError(t, errors.Unwrap(sErr))
 
-	_, err = s.Split(`,a`)
+	_, err = s.Split(",a")
 	require.Error(t, err)
-	require.Equal(t, `whoops at position 0`, err.Error())
+	require.Equal(t, "whoops at position 0", err.Error())
 	sErr, ok = err.(SplittingError)
 	require.True(t, ok)
 	require.Equal(t, OptionFail, sErr.Type())
@@ -115,7 +116,7 @@ func TestSplitAlwaysReturnsSplittingError(t *testing.T) {
 	require.NoError(t, sErr.Unwrap())
 	require.NoError(t, errors.Unwrap(sErr))
 
-	_, err = s.Split(`a`, &errorOption{})
+	_, err = s.Split("a", &errorOption{})
 	require.Error(t, err)
 	require.Equal(t, "error option", err.Error())
 	sErr, ok = err.(SplittingError)

--- a/options_test.go
+++ b/options_test.go
@@ -1,12 +1,13 @@
 package splitter
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestSplitOptionsMerge(t *testing.T) {
-	s, err := NewSplitter('/')
+	s, err := NewSplitter("/")
 	require.NoError(t, err)
 	const testStr = `/a/b/c/`
 	pts, err := s.Split(testStr)
@@ -32,7 +33,7 @@ func TestSplitOptionsMerge(t *testing.T) {
 }
 
 func TestOption_TrimSpaces(t *testing.T) {
-	s, err := NewSplitter('/')
+	s, err := NewSplitter("/")
 	require.NoError(t, err)
 
 	pts, err := s.Split(` / / `, TrimSpaces)
@@ -66,7 +67,7 @@ func TestOption_TrimSpaces(t *testing.T) {
 }
 
 func TestOption_Trim(t *testing.T) {
-	s, err := NewSplitter('/')
+	s, err := NewSplitter("/")
 	require.NoError(t, err)
 
 	trimmer := Trim(" \t\n")
@@ -101,7 +102,7 @@ func TestOption_Trim(t *testing.T) {
 }
 
 func TestOption_NoEmpties(t *testing.T) {
-	s, err := NewSplitter('/')
+	s, err := NewSplitter("/")
 	require.NoError(t, err)
 
 	pts, err := s.Split(`a/b/c`, NoEmpties)
@@ -114,7 +115,7 @@ func TestOption_NoEmpties(t *testing.T) {
 }
 
 func TestOption_NoEmptiesMsg(t *testing.T) {
-	s, err := NewSplitter('/')
+	s, err := NewSplitter("/")
 	require.NoError(t, err)
 
 	_, err = s.Split(`a//c`, NoEmptiesMsg("whoops at position %d"))
@@ -123,7 +124,7 @@ func TestOption_NoEmptiesMsg(t *testing.T) {
 }
 
 func TestOption_IgnoreEmpties(t *testing.T) {
-	s, err := NewSplitter('/')
+	s, err := NewSplitter("/")
 	require.NoError(t, err)
 
 	pts, err := s.Split(`a/b/c`, IgnoreEmpties)
@@ -148,7 +149,7 @@ func TestOption_IgnoreEmpties(t *testing.T) {
 }
 
 func TestOption_NotEmptyFirst(t *testing.T) {
-	s, err := NewSplitter('/')
+	s, err := NewSplitter("/")
 	require.NoError(t, err)
 
 	pts, err := s.Split(`a/b/c`, NotEmptyFirst)
@@ -161,7 +162,7 @@ func TestOption_NotEmptyFirst(t *testing.T) {
 }
 
 func TestOption_NotEmptyFirstMsg(t *testing.T) {
-	s, err := NewSplitter('/')
+	s, err := NewSplitter("/")
 	require.NoError(t, err)
 
 	_, err = s.Split(`/a/b/c`, NotEmptyFirstMsg("whoops"))
@@ -170,7 +171,7 @@ func TestOption_NotEmptyFirstMsg(t *testing.T) {
 }
 
 func TestOption_IgnoreEmptyFirst(t *testing.T) {
-	s, err := NewSplitter('/')
+	s, err := NewSplitter("/")
 	require.NoError(t, err)
 
 	pts, err := s.Split(`a/b/c`, IgnoreEmptyFirst)
@@ -183,7 +184,7 @@ func TestOption_IgnoreEmptyFirst(t *testing.T) {
 }
 
 func TestOption_NotEmptyLast(t *testing.T) {
-	s, err := NewSplitter('/')
+	s, err := NewSplitter("/")
 	require.NoError(t, err)
 
 	pts, err := s.Split(`a/b/c`, NotEmptyLast)
@@ -196,7 +197,7 @@ func TestOption_NotEmptyLast(t *testing.T) {
 }
 
 func TestOption_NotEmptyLastMsg(t *testing.T) {
-	s, err := NewSplitter('/')
+	s, err := NewSplitter("/")
 	require.NoError(t, err)
 
 	_, err = s.Split(`a/b/c/`, NotEmptyLastMsg("whoops"))
@@ -205,7 +206,7 @@ func TestOption_NotEmptyLastMsg(t *testing.T) {
 }
 
 func TestOption_IgnoreEmptyLast(t *testing.T) {
-	s, err := NewSplitter('/')
+	s, err := NewSplitter("/")
 	require.NoError(t, err)
 
 	pts, err := s.Split(`a/b/c`, IgnoreEmptyLast)
@@ -218,7 +219,7 @@ func TestOption_IgnoreEmptyLast(t *testing.T) {
 }
 
 func TestOption_NotEmptyInners(t *testing.T) {
-	s, err := NewSplitter('/')
+	s, err := NewSplitter("/")
 	require.NoError(t, err)
 
 	pts, err := s.Split(`/a//c/`)
@@ -235,7 +236,7 @@ func TestOption_NotEmptyInners(t *testing.T) {
 }
 
 func TestOption_NotEmptyInnersMsg(t *testing.T) {
-	s, err := NewSplitter('/')
+	s, err := NewSplitter("/")
 	require.NoError(t, err)
 
 	pts, err := s.Split(`/a//c/`)
@@ -252,7 +253,7 @@ func TestOption_NotEmptyInnersMsg(t *testing.T) {
 }
 
 func TestOption_IgnoreEmptyInners(t *testing.T) {
-	s, err := NewSplitter('/')
+	s, err := NewSplitter("/")
 	require.NoError(t, err)
 
 	pts, err := s.Split(`/a//c/`)
@@ -275,7 +276,7 @@ func TestOption_IgnoreEmptyInners(t *testing.T) {
 }
 
 func TestOption_NotEmptyOuters(t *testing.T) {
-	s, err := NewSplitter('/')
+	s, err := NewSplitter("/")
 	require.NoError(t, err)
 
 	pts, err := s.Split(`/a//c/`)
@@ -299,7 +300,7 @@ func TestOption_NotEmptyOuters(t *testing.T) {
 }
 
 func TestOption_NotEmptyOutersMsg(t *testing.T) {
-	s, err := NewSplitter('/')
+	s, err := NewSplitter("/")
 	require.NoError(t, err)
 
 	pts, err := s.Split(`/a//c/`)
@@ -323,7 +324,7 @@ func TestOption_NotEmptyOutersMsg(t *testing.T) {
 }
 
 func TestOption_IgnoreEmptyOuters(t *testing.T) {
-	s, err := NewSplitter('/')
+	s, err := NewSplitter("/")
 	require.NoError(t, err)
 
 	pts, err := s.Split(`/a//c/`)
@@ -360,7 +361,7 @@ func TestOption_IgnoreEmptyOuters(t *testing.T) {
 }
 
 func TestOption_NoContiguousQuotes(t *testing.T) {
-	s, err := NewSplitter('/', DoubleQuotes)
+	s, err := NewSplitter("/", DoubleQuotes)
 	require.NoError(t, err)
 
 	_, err = s.Split(`a/"b" "b"/c`, NoContiguousQuotes)
@@ -372,7 +373,7 @@ func TestOption_NoContiguousQuotes(t *testing.T) {
 }
 
 func TestOption_NoContiguousQuotesMsg(t *testing.T) {
-	s, err := NewSplitter('/', DoubleQuotes)
+	s, err := NewSplitter("/", DoubleQuotes)
 	require.NoError(t, err)
 
 	_, err = s.Split(`a/"b""b"/c/`, NoContiguousQuotesMsg("whoops"))
@@ -381,7 +382,7 @@ func TestOption_NoContiguousQuotesMsg(t *testing.T) {
 }
 
 func TestOption_NoMultiQuotes(t *testing.T) {
-	s, err := NewSplitter('/', DoubleQuotes)
+	s, err := NewSplitter("/", DoubleQuotes)
 	require.NoError(t, err)
 
 	_, err = s.Split(`a/"b"/c`, NoMultiQuotes)
@@ -393,7 +394,7 @@ func TestOption_NoMultiQuotes(t *testing.T) {
 }
 
 func TestOption_NoMultiQuotesMsg(t *testing.T) {
-	s, err := NewSplitter('/', DoubleQuotes)
+	s, err := NewSplitter("/", DoubleQuotes)
 	require.NoError(t, err)
 
 	_, err = s.Split(`a/"b""b"/c`, NoMultiQuotesMsg("whoops"))
@@ -402,7 +403,7 @@ func TestOption_NoMultiQuotesMsg(t *testing.T) {
 }
 
 func TestOption_NoMultis(t *testing.T) {
-	s, err := NewSplitter('/', DoubleQuotes, Parenthesis)
+	s, err := NewSplitter("/", DoubleQuotes, Parenthesis)
 	require.NoError(t, err)
 
 	_, err = s.Split(`a/"b"/(,)`, NoMultis)
@@ -414,7 +415,7 @@ func TestOption_NoMultis(t *testing.T) {
 }
 
 func TestOption_NoMultisMsg(t *testing.T) {
-	s, err := NewSplitter('/', DoubleQuotes, Parenthesis)
+	s, err := NewSplitter("/", DoubleQuotes, Parenthesis)
 	require.NoError(t, err)
 
 	_, err = s.Split(`a/"b" ()/(,)`, NoMultisMsg("whoops"))
@@ -423,7 +424,7 @@ func TestOption_NoMultisMsg(t *testing.T) {
 }
 
 func TestOption_StripQuotes(t *testing.T) {
-	s, err := NewSplitter('/', DoubleQuotes)
+	s, err := NewSplitter("/", DoubleQuotes)
 	require.NoError(t, err)
 
 	pts, err := s.Split(`a/"b"`, StripQuotes)
@@ -452,7 +453,7 @@ func TestOption_StripQuotes(t *testing.T) {
 }
 
 func TestOption_UnescapeQuotes(t *testing.T) {
-	s, err := NewSplitter('/', DoubleQuotesDoubleEscaped)
+	s, err := NewSplitter("/", DoubleQuotesDoubleEscaped)
 	require.NoError(t, err)
 
 	pts, err := s.Split(`"a"""/"b""b""b"`)

--- a/splitter.go
+++ b/splitter.go
@@ -192,8 +192,10 @@ func (ctx *splitterContext) split() ([]string, error) {
 	if ctx.inAny() {
 		return nil, newSplittingError(Unclosed, ctx.current.openPos, ctx.current.enc.Start, &ctx.current.enc)
 	}
-	if err := ctx.purge(ctx.len, 0, true); err != nil {
-		return nil, err
+	for j := range ctx.splitter.separator {
+		if err := ctx.purge(ctx.len, j, true); err != nil {
+			return nil, err
+		}
 	}
 	return ctx.captured, nil
 }
@@ -243,7 +245,7 @@ func (ctx *splitterContext) purge(i, j int, isLast bool) (err error) {
 		} else {
 			ctx.skipped++
 		}
-		ctx.lastAt = i + 1
+		ctx.lastAt = i + len(ctx.splitter.separator) // was 1
 		ctx.delims = make([]SubPart, 0)
 	}
 	return

--- a/splitter.go
+++ b/splitter.go
@@ -157,7 +157,7 @@ func (ctx *splitterContext) split() ([]string, error) {
 		ctx.rune = ctx.runes[ctx.pos]
 		check := false
 		for j, s := range ctx.splitter.separator {
-			if len(ctx.runes) >= ctx.pos+j && ctx.runes[ctx.pos+j] == s {
+			if len(ctx.runes) > ctx.pos+j && ctx.runes[ctx.pos+j] == s {
 				check = true
 			} else {
 				check = false

--- a/splitter.go
+++ b/splitter.go
@@ -127,7 +127,7 @@ func newSplitterContext(str string, splitter *splitter, options []Option) *split
 	for i := range runes {
 		check := false
 		for j, s := range splitter.separator {
-			if len(runes) >= i+j && runes[i+j] == s {
+			if len(runes) > i+j && runes[i+j] == s {
 				check = true
 			} else {
 				check = false
@@ -165,9 +165,9 @@ func (ctx *splitterContext) split() ([]string, error) {
 			}
 		}
 		if check {
-			for j := range ctx.splitter.separator {
+			for j := 0; j < len(ctx.splitter.separator); j++ {
 				if !ctx.inAny() {
-					if err := ctx.purge(ctx.pos+j, false); err != nil {
+					if err := ctx.purge(ctx.pos+j, j, false); err != nil {
 						return nil, err
 					}
 				}
@@ -192,7 +192,7 @@ func (ctx *splitterContext) split() ([]string, error) {
 	if ctx.inAny() {
 		return nil, newSplittingError(Unclosed, ctx.current.openPos, ctx.current.enc.Start, &ctx.current.enc)
 	}
-	if err := ctx.purge(ctx.len, true); err != nil {
+	if err := ctx.purge(ctx.len, 0, true); err != nil {
 		return nil, err
 	}
 	return ctx.captured, nil
@@ -225,7 +225,7 @@ func (ctx *splitterContext) isQuoteEnd() (isEnd bool, inQuote bool) {
 	return
 }
 
-func (ctx *splitterContext) purge(i int, isLast bool) (err error) {
+func (ctx *splitterContext) purge(i, j int, isLast bool) (err error) {
 	if i >= ctx.lastAt {
 		ctx.purgeFixed(i)
 		capture := string(ctx.runes[ctx.lastAt:i])
@@ -238,7 +238,7 @@ func (ctx *splitterContext) purge(i int, isLast bool) (err error) {
 			}
 		}
 		err = asSplittingError(err, ctx.lastAt)
-		if addIt {
+		if j == 0 && addIt {
 			ctx.captured = append(ctx.captured, capture)
 		} else {
 			ctx.skipped++

--- a/splitter_test.go
+++ b/splitter_test.go
@@ -153,27 +153,27 @@ func TestSplitter_SplitStr(t *testing.T) {
 			Escape:    '\\',
 		},
 	}
-	s, _ := NewSplitter("aaa/", encs...)
+	s, _ := NewSplitter(`AAA`, encs...)
 
 	testCases := []struct {
 		str    string
 		expect []string
 	}{
 		{
-			`aaa/fooaaa/{aaa/}`,
-			[]string{``, `foo`, `{aaa/}`},
+			`AAAfooAAA{AAA}`,
+			[]string{``, `foo`, `{AAA}`},
 		},
 		{
-			`aaa/fooaaa/{{aaa/}}`,
-			[]string{``, `foo`, `{{aaa/}}`},
+			`AAAfooAAA{{AAA}}`,
+			[]string{``, `foo`, `{{AAA}}`},
 		},
 		{
-			`fooaaa/baraaa/"bazaaa/qux"aaa/'quxaaa/"aaa/"aaa/"aaa/"aaa/"aaa/"'aaa/`,
-			[]string{`foo`, `bar`, `"bazaaa/qux"`, `'quxaaa/"aaa/"aaa/"aaa/"aaa/"aaa/"'`, ``},
+			`fooAAAbarAAA"bazAAAqux"AAA'quxAAA"AAA"AAA"AAA"AAA"AAA"'AAA`,
+			[]string{`foo`, `bar`, `"bazAAAqux"`, `'quxAAA"AAA"AAA"AAA"AAA"AAA"'`, ``},
 		},
 		{
-			`fooaaa/"\"aaa/"aaa/bar`,
-			[]string{`foo`, `"\"aaa/"`, `bar`},
+			`fooAAA'\'AAA'AAAbar`,
+			[]string{`foo`, `'\'AAA'`, `bar`},
 		},
 		{
 			``,
@@ -184,11 +184,11 @@ func TestSplitter_SplitStr(t *testing.T) {
 			[]string{` `},
 		},
 		{
-			`aaa/`,
+			`AAA`,
 			[]string{``, ``},
 		},
 		{
-			`aaa/aaa/`,
+			`AAAAAA`,
 			[]string{``, ``, ``},
 		},
 	}
@@ -196,10 +196,10 @@ func TestSplitter_SplitStr(t *testing.T) {
 		t.Run(fmt.Sprintf("[%d]%s", i+1, tc.str), func(t *testing.T) {
 			result, err := s.Split(tc.str)
 
-			fmt.Printf("\nMYTEST: %s", tc.str)
+			/*fmt.Printf("\nMYTEST: %s", tc.str)
 			for _, r := range result {
 				fmt.Printf(" [%s] ", r)
-			}
+			}*/
 
 			require.NoError(t, err)
 			require.Equal(t, tc.expect, result)


### PR DESCRIPTION
Hi this PR is based on a modification I needed in order to have this library to split on a string instead of a single rune.

Our use case requires to split an sql file on '/' character, so it was a good fit, but now we also want to secure the fact the slash  must be alone on its own line, so the separator woud be "\n/\n", and I needed that feature.

I'm glad your code was easy enought to read and understand so here is my contribution !

All test passed before and after the change, I added some to test our use case, but did not create much complicated ones than the ones already present.

Maybe it would be good to have an interface, so the lib handle both rune and strings... I ll gladly redo a PR if you want this on another branch...

PS: the third commit (8016852527730b678741802e8f836a55a1524422) I'm very unsure about it since tests passes anyway but it seems quite logical to purge on each string's character, IDK...

Thank you